### PR TITLE
Replace deprecated Streamlit query param API

### DIFF
--- a/app_mcp_http.py
+++ b/app_mcp_http.py
@@ -316,9 +316,12 @@ components.html(
     """,
     height=0,
 )
-params = st.experimental_get_query_params()
+params = st.query_params
 try:
-    width = int(params.get("w", [0])[0])
+    w_param = params.get("w", 0)
+    if isinstance(w_param, list):
+        w_param = w_param[0]
+    width = int(w_param)
     CHART_HEIGHT = max(200, int(width * 0.6))
 except Exception:
     CHART_HEIGHT = DEFAULT_CHART_HEIGHT


### PR DESCRIPTION
## Summary
- replace deprecated `st.experimental_get_query_params` with new `st.query_params`

## Testing
- `python -m py_compile app_mcp_http.py`


------
https://chatgpt.com/codex/tasks/task_e_68b535049c2083319cb76041fa4bb278