### PR TITLE
Improve chart accessibility with high-contrast style

### DIFF
--- a/app_mcp_http.py
+++ b/app_mcp_http.py
@@ -291,6 +291,8 @@ st.markdown(
     """
     <style>
     .main .block-container{padding-top:1rem;padding-left:0.5rem;padding-right:0.5rem;}
+    .vega-bindings input, .mark-text { font-size: 12px !important; }
+    body { background-color:#fff; color:#000; }
     </style>
     """,
     unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- Increase Vega input and mark text font size
- Apply high-contrast body colors for better readability

## Testing
- `python -m py_compile app_mcp_http.py`
- `streamlit run app_mcp_http.py --server.headless true --server.port 8501` & `curl -s http://localhost:8501/?w=375 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b539d1dd9c8331bc32feb31243344f